### PR TITLE
Option to use more flexible keyword searching

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -105,6 +105,9 @@ def SetupUrls(sitetype, base, lang='en'):
         ctx['NAR_BY'       ]='Narrated By'
         ctx['NAR_BY_INFO'  ]='Narrated by'
 
+    # Match titles using more flexible keyword search
+    if Prefs['keyword_searching']:
+        urlsearchtitle="advsearchKeywords="
 
     AUD_BASE_URL='https://' + str(base) + '/'
     AUD_TITLE_URL=urlsearchtitle

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -9,6 +9,11 @@
     "values"  : ["www.audible.com","www.audible.co.uk","www.audible.com.au","www.audible.de","www.audible.fr","www.audible.it"],
     "default" : "www.audible.com"
 },{
+    "id": "keyword_searching",
+    "label": "Match titles using more flexible keyword search",
+    "type": "bool",
+    "default": "false"
+},{
 	"id": "debug",
 	"label": "Ouput debugging info in logs",
 	"type": "bool",


### PR DESCRIPTION
I've been having better results using `advsearchKeywords` search instead of explicitly specifying a title search (which is much more strict and fails on things like numbers prefixed etc.).  Author can still be specified which results in a more flexible title search still sensibly constrained when author known.

Nice side effect is that `advsearchKeywords=` survives when searching the `.com` site from outside the US - unlike `title=`.